### PR TITLE
Talk about mem::take instead of mem::replace (#200)

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -8,7 +8,7 @@
   - [The `Default` Trait](./idioms/default.md)
   - [Collections Are Smart Pointers](./idioms/deref.md)
   - [Finalisation in Destructors](./idioms/dtor-finally.md)
-  - [`mem::replace(_)`](./idioms/mem-replace.md)
+  - [`mem::{take(_), replace(_)}`](./idioms/mem-replace.md)
   - [On-Stack Dynamic Dispatch](./idioms/on-stack-dyn-dispatch.md)
   - [Foreign function interface usage](./idioms/ffi-intro.md)
     - [Idiomatic Errors](./idioms/ffi-errors.md)

--- a/idioms/mem-replace.md
+++ b/idioms/mem-replace.md
@@ -1,4 +1,4 @@
-# `mem::replace` to keep owned values in changed enums
+# `mem::{take(_), replace(_)}` to keep owned values in changed enums
 
 ## Description
 
@@ -29,7 +29,7 @@ fn a_to_b(e: &mut MyEnum) {
         // (note that empty strings don't allocate).
         // Then, construct the new enum variant (which will
         // be assigned to `*e`, because it is the result of the `if let` expression).
-        MyEnum::B { name: mem::replace(name, String::new()) }
+        MyEnum::B { name: mem::take(name) }
 
     // In all other cases, we return immediately, thus skipping the assignment
     } else { return }
@@ -38,7 +38,7 @@ fn a_to_b(e: &mut MyEnum) {
 
 This also works with more variants:
 
-```Rust
+```rust
 use std::mem;
 
 enum MultiVariateEnum {
@@ -49,12 +49,12 @@ enum MultiVariateEnum {
 }
 
 fn swizzle(e: &mut MultiVariateEnum) {
-    use self::MultiVariateEnum::*;
+    use MultiVariateEnum::*;
     *e = match *e {
         // Ownership rules do not allow taking `name` by value, but we cannot
         // take the value out of a mutable reference, unless we replace it:
-        A { ref mut name } => B { name: mem::replace(name, String::new()) },
-        B { ref mut name } => A { name: mem::replace(name, String::new()) },
+        A { ref mut name } => B { name: mem::take(name) },
+        B { ref mut name } => A { name: mem::take(name) },
         C => D,
         D => C
     }
@@ -75,10 +75,14 @@ into our `MyEnum::B`, but that would be an instance of the [Clone to satisfy
 the borrow checker] antipattern. Anyway, we can avoid the extra allocation by
 changing `e` with only a mutable borrow.
 
-`mem::replace` lets us swap out the value, replacing it with something else. In
-this case, we put in an empty `String`, which does not need to allocate. As a
-result, we get the original `name` *as an owned value*. We can then wrap this in
-another enum.
+`mem::take` lets us swap out the value, replacing it with it's default value,
+and returning the previous value. For `String`, the default value is an empty
+`String`, which does not need to allocate. As a result, we get the original
+`name` *as an owned value*. We can then wrap this in another enum.
+
+__NOTE:__ `mem::replace` is very similar, but allows us to specify what to
+replace the value with. An equivalent to our `mem::take` line would be
+`mem::replace(name, String::new())`.
 
 Note, however, that if we are using an `Option` and want to replace its
 value with a `None`, `Option`’s `take()` method provides a shorter and
@@ -94,6 +98,10 @@ This gets a bit wordy. Getting it wrong repeatedly will make you hate the
 borrow checker. The compiler may fail to optimize away the double store,
 resulting in reduced performance as opposed to what you'd do in unsafe
 languages.
+
+Furthermore, the type you are taking needs to implement the [`Default`
+trait](./default.md). However, if the type you're working with doesn't
+implement this, you can instead use `mem::replace`.
 
 ## Discussion
 


### PR DESCRIPTION
* Talk about std::take instead of std::replace

* Mention mem::replace in mem::take idiom

* Fix example code so it can compile and execute

* Clarify the need for Default in disadvantages

* Update idioms/mem-take.md

* Add note tag to section on mem::replace

Co-authored-by: simonsan <14062932+simonsan@users.noreply.github.com>

* Follow on from previous paragraph in mem::take

* Change title to include mem::take

Co-authored-by: simonsan <14062932+simonsan@users.noreply.github.com>